### PR TITLE
bugfix for generating IIASA template while merging scenarios

### DIFF
--- a/R/mcl.R
+++ b/R/mcl.R
@@ -239,7 +239,7 @@ generate <- function(scenctl,
             vars <- names(rslts)
             for(i in seq(1,length(vars))) {
                 var <- vars[i]
-                vardf <- rslts[var]
+                vardf <- rslts[[var]]
                 if(nrow(vardf) == 0 )
                     rslts[var] <- NULL
             }


### PR DESCRIPTION
use double brackets to extract data frame rather than list when writing out IIASA template and merging scenarios